### PR TITLE
Use class-type-IDs from build JDK, avoid type-ID inconsistencies

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrSubstitutions.java
@@ -116,16 +116,6 @@ final class Target_jdk_jfr_internal_Logger {
     }
 }
 
-@TargetClass(className = "jdk.jfr.internal.MetadataRepository", onlyWith = JfrAvailability.WithJfr.class)
-final class Target_jdk_jfr_internal_MetadataRepository {
-    @Substitute
-    private void unregisterUnloaded() {
-        // JFR.TODO: once traceid related work is fixed, this
-        // substitution should be removed in favor of the original
-        // implementation
-    }
-}
-
 @Substitute
 @TargetClass(className = "jdk.jfr.internal.EventWriter", onlyWith = JfrAvailability.WithJfr.class)
 final class Target_jdk_jfr_internal_EventWriter {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/traceid/JfrTraceId.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/traceid/JfrTraceId.java
@@ -29,6 +29,7 @@ package com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.traceid;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
+import jdk.jfr.internal.JVM;
 import org.graalvm.nativeimage.ImageSingletons;
 
 import com.oracle.svm.core.jdk.jfr.JfrAvailability;
@@ -58,7 +59,6 @@ public class JfrTraceId {
     private static final long JDK_JFR_EVENT_KLASS = 32;
     private static final long EVENT_HOST_KLASS = 64;
 
-    private static final AtomicLong classCounter = new AtomicLong(MaxJfrEventId + 100);
     private static final AtomicLong classLoaderCounter = new AtomicLong(1);
     private static final AtomicLong packageCounter = new AtomicLong(1);
     private static final AtomicLong moduleCounter = new AtomicLong(1);
@@ -158,8 +158,8 @@ public class JfrTraceId {
     public static long assign(Class<?> clazz) {
         assert clazz != null;
         assert getTraceIdMap().getId(clazz) == -1;
-        long nextId = classCounter.getAndIncrement();
-        getTraceIdMap().setId(clazz, nextId << TRACE_ID_SHIFT);
+        long typeId = JVM.getJVM().getTypeId(clazz);
+        getTraceIdMap().setId(clazz, typeId << TRACE_ID_SHIFT);
         if (!setSystemEventClass(clazz)) {
             Class<?> superClazz = clazz.getSuperclass();
             if (superClazz != null) {
@@ -172,7 +172,7 @@ public class JfrTraceId {
             }
         }
 
-        return nextId;
+        return typeId;
     }
 
     public static long assign(ClassLoader classLoader) {


### PR DESCRIPTION
We used to generate our own set of type-IDs for classes until now. This is problematic, because TypeLibrary *also* builds a table of class->typeID mappings, and it is generated at build-time, using the typeIDs from the build VM. This leads to two conflicting sets of type-IDs which leads to stuff like prematurely unloading evenc classes in MetadataRepository.unregisterUnloaded(). The solution is to pick up the type-IDs from the build VM and stick with those.

Testing:
 [x] EventCommit test still works (this test suffered from missing event because of premature unloading)
