### PR TITLE
Fixes to JFR option processing - times in ms, add "filename"

### DIFF
--- a/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/JfrOptionsTest.java
+++ b/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/JfrOptionsTest.java
@@ -79,9 +79,9 @@ public class JfrOptionsTest {
     @Test
     public void testTimeOptions() {
         JfrOptions.StartFlightRecordingOption.update(EconomicMap.create(),"delay=10s,maxage=1h,duration=2m");
-        Assert.assertEquals(10, JfrOptions.getRecordingDelay());
-        Assert.assertEquals(360, JfrOptions.getMaxAge());
-        Assert.assertEquals(120, JfrOptions.getDuration());
+        Assert.assertEquals(10000, JfrOptions.getRecordingDelay());
+        Assert.assertEquals(360000, JfrOptions.getMaxAge());
+        Assert.assertEquals(120000, JfrOptions.getDuration());
     }
 
     @Test
@@ -129,10 +129,10 @@ public class JfrOptionsTest {
         Assert.assertEquals(false, JfrOptions.getDumpOnExit());
         Assert.assertEquals("recording", JfrOptions.getRecordingName());
         Assert.assertEquals("/path/to/settings", JfrOptions.getRecordingSettingsFile());
-        Assert.assertEquals(10, JfrOptions.getRecordingDelay());
-        Assert.assertEquals(60, JfrOptions.getDuration());
+        Assert.assertEquals(10000, JfrOptions.getRecordingDelay());
+        Assert.assertEquals(60000, JfrOptions.getDuration());
         Assert.assertEquals(true, JfrOptions.isPersistedToDisk());
-        Assert.assertEquals(360, JfrOptions.getMaxAge());
+        Assert.assertEquals(360000, JfrOptions.getMaxAge());
         Assert.assertEquals(10*K, JfrOptions.getMaxRecordingSize());
         Assert.assertEquals(true, JfrOptions.trackPathToGcRoots());
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrOptions.java
@@ -79,6 +79,7 @@ public class JfrOptions {
     private static final String REPOSITORY = "repository";
     // Arguments from JfrDcmds.cpp
     private static final String DUMPONEXIT = "dumponexit";
+    private static final String FILENAME = "filename";
     private static final String NAME = "name";
     private static final String SETTINGS = "settings";
     private static final String DELAY = "delay";
@@ -179,7 +180,6 @@ public class JfrOptions {
         return true;
     }
 
-
     public static boolean parseStartFlightRecordingOption(String args) {
         if (args.equals("")) {
             // -XX:StartFlightRecording without any delimiter and values
@@ -236,6 +236,9 @@ public class JfrOptions {
                         break;
                     case DISK:
                         persistToDisk = Boolean.parseBoolean(val);
+                        break;
+                    case FILENAME:
+                        filename = val;
                         break;
                     case GCROOTS:
                         pathToGcRoots = Boolean.parseBoolean(val);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrOptions.java
@@ -271,16 +271,18 @@ public class JfrOptions {
 
     private static long parseTimeOption(String arg) {
         String adjusted = arg.toLowerCase();
-        if (adjusted.contains("s")) {
-            return Long.parseLong(adjusted.split("s")[0]);
-        } else if (adjusted.contains("m")) {
-            return Long.parseLong(adjusted.split("m")[0]) * 60;
-        } else if (adjusted.contains("h")) {
-            return Long.parseLong(adjusted.split("h")[0]) * 360;
-        } else if (adjusted.contains("d")) {
-            return Long.parseLong(adjusted.split("d")[0]) * 60 * 60 * 24;
+        if (adjusted.endsWith("ms")) {
+            return Long.parseLong(adjusted.split("ms")[0]);
+        } else if (adjusted.endsWith("s")) {
+            return Long.parseLong(adjusted.split("s")[0]) * 1000;
+        } else if (adjusted.endsWith("m")) {
+            return Long.parseLong(adjusted.split("m")[0]) * 1000 * 60;
+        } else if (adjusted.endsWith("h")) {
+            return Long.parseLong(adjusted.split("h")[0]) * 1000 * 360;
+        } else if (adjusted.endsWith("d")) {
+            return Long.parseLong(adjusted.split("d")[0]) * 1000 * 60 * 60 * 24;
         } else {
-            throw new IllegalArgumentException("Invalid time specified for " + arg + " specify time lengths with s, m, h, or d");
+            throw new IllegalArgumentException("Invalid time specified for " + arg + " specify time lengths with ms, s, m, h, or d");
         }
     }
 


### PR DESCRIPTION
This PR does two things:

1) all times will be in milliseconds, not seconds.  'ms' is added as a new time scale.  This is especially important for a short-lived process with a sub-second delay before JFR starts recording.

2) 'filename' is now parsed and set properly.  Before it was allowed but ignored.