### PR TITLE
Add command line flight recorder startup

### DIFF
--- a/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/JfrOptionsTest.java
+++ b/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/JfrOptionsTest.java
@@ -79,9 +79,9 @@ public class JfrOptionsTest {
     @Test
     public void testTimeOptions() {
         JfrOptions.StartFlightRecordingOption.update(EconomicMap.create(),"delay=10s,maxage=1h,duration=2m");
-        Assert.assertEquals(10, JfrOptions.getRecordingDelay());
-        Assert.assertEquals(360, JfrOptions.getMaxAge());
-        Assert.assertEquals(120, JfrOptions.getDuration());
+        Assert.assertEquals(10000, JfrOptions.getRecordingDelay());
+        Assert.assertEquals(360000, JfrOptions.getMaxAge());
+        Assert.assertEquals(120000, JfrOptions.getDuration());
     }
 
     @Test
@@ -129,10 +129,10 @@ public class JfrOptionsTest {
         Assert.assertEquals(false, JfrOptions.getDumpOnExit());
         Assert.assertEquals("recording", JfrOptions.getRecordingName());
         Assert.assertEquals("/path/to/settings", JfrOptions.getRecordingSettingsFile());
-        Assert.assertEquals(10, JfrOptions.getRecordingDelay());
-        Assert.assertEquals(60, JfrOptions.getDuration());
+        Assert.assertEquals(10000, JfrOptions.getRecordingDelay());
+        Assert.assertEquals(60000, JfrOptions.getDuration());
         Assert.assertEquals(true, JfrOptions.isPersistedToDisk());
-        Assert.assertEquals(360, JfrOptions.getMaxAge());
+        Assert.assertEquals(360000, JfrOptions.getMaxAge());
         Assert.assertEquals(10*K, JfrOptions.getMaxRecordingSize());
         Assert.assertEquals(true, JfrOptions.trackPathToGcRoots());
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrFeature.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrFeature.java
@@ -32,12 +32,14 @@ import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.oracle.svm.core.jdk.RuntimeSupport;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
 
 import com.oracle.svm.core.annotate.AutomaticFeature;
 import com.oracle.svm.core.jdk.jfr.logging.JfrLogger;
+import com.oracle.svm.core.jdk.jfr.remote.JfrAutoSessionManager;
 import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.traceid.JfrTraceId;
 
 import jdk.internal.event.Event;
@@ -47,6 +49,15 @@ public class JfrFeature implements Feature {
     @Override
     public void afterRegistration(AfterRegistrationAccess access) {
         ImageSingletons.add(JfrRuntimeAccess.class, new JfrRuntimeAccessImpl());
+    }
+
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess access) {
+        if (JfrAvailability.withJfr) {
+            // JFR-TODO: test command line options for startup timer, file output, etc.
+            RuntimeSupport.getRuntimeSupport().addStartupHook(JfrAutoSessionManager::startupHook);
+            RuntimeSupport.getRuntimeSupport().addShutdownHook(JfrAutoSessionManager::shutdownHook);
+        }
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrOptions.java
@@ -79,6 +79,7 @@ public class JfrOptions {
     private static final String REPOSITORY = "repository";
     // Arguments from JfrDcmds.cpp
     private static final String DUMPONEXIT = "dumponexit";
+    private static final String FILENAME = "filename";
     private static final String NAME = "name";
     private static final String SETTINGS = "settings";
     private static final String DELAY = "delay";
@@ -179,7 +180,6 @@ public class JfrOptions {
         return true;
     }
 
-
     public static boolean parseStartFlightRecordingOption(String args) {
         if (args.equals("")) {
             // -XX:StartFlightRecording without any delimiter and values
@@ -236,6 +236,9 @@ public class JfrOptions {
                         break;
                     case DISK:
                         persistToDisk = Boolean.parseBoolean(val);
+                        break;
+                    case FILENAME:
+                        filename = val;
                         break;
                     case GCROOTS:
                         pathToGcRoots = Boolean.parseBoolean(val);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrOptions.java
@@ -271,16 +271,18 @@ public class JfrOptions {
 
     private static long parseTimeOption(String arg) {
         String adjusted = arg.toLowerCase();
-        if (adjusted.contains("s")) {
-            return Long.parseLong(adjusted.split("s")[0]);
-        } else if (adjusted.contains("m")) {
-            return Long.parseLong(adjusted.split("m")[0]) * 60;
-        } else if (adjusted.contains("h")) {
-            return Long.parseLong(adjusted.split("h")[0]) * 360;
-        } else if (adjusted.contains("d")) {
-            return Long.parseLong(adjusted.split("d")[0]) * 60 * 60 * 24;
+        if (adjusted.endsWith("ms")) {
+            return Long.parseLong(adjusted.split("ms")[0]);
+        } else if (adjusted.endsWith("s")) {
+            return Long.parseLong(adjusted.split("s")[0]) * 1000;
+        } else if (adjusted.endsWith("m")) {
+            return Long.parseLong(adjusted.split("m")[0]) * 1000 * 60;
+        } else if (adjusted.endsWith("h")) {
+            return Long.parseLong(adjusted.split("h")[0]) * 1000 * 360;
+        } else if (adjusted.endsWith("d")) {
+            return Long.parseLong(adjusted.split("d")[0]) * 1000 * 60 * 60 * 24;
         } else {
-            throw new IllegalArgumentException("Invalid time specified for " + arg + " specify time lengths with s, m, h, or d");
+            throw new IllegalArgumentException("Invalid time specified for " + arg + " specify time lengths with ms, s, m, h, or d");
         }
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrOptions.java
@@ -100,6 +100,7 @@ public class JfrOptions {
     private static int stackDepth = 64;
 
     // Delay, Duration, Max Age are time arguments
+    private static boolean startRecordingAutomatically = false;
     private static long delay = 0;
     private static long duration = 0;
     private static long maxAge = 0; // 0 is a special value indicating no limit
@@ -139,6 +140,7 @@ public class JfrOptions {
         protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, String oldValue, String newValue) {
             // Substrate parses it into option=value,option2=value,.... We can pass it on to our own parsing methods from here
             parseStartFlightRecordingOption(newValue);
+            startRecordingAutomatically = true;
             // Do the sanity checks to make sure we have valid options
             if (!adjustMemoryOptions()) {
                 throw new IllegalArgumentException("Failed to validate memory arguments");
@@ -339,6 +341,10 @@ public class JfrOptions {
         }
         Target_jdk_jfr_internal_JVM.getJVM().setFileNotification(chunkSize);
         maxChunkSize = chunkSize;
+    }
+
+    public static boolean getStartRecordingAutomatically() {
+        return startRecordingAutomatically;
     }
 
     public static int getGlobalBufferSize() {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/JfrAutoSessionManager.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/JfrAutoSessionManager.java
@@ -1,3 +1,29 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package com.oracle.svm.core.jdk.jfr.remote;
 
 import com.oracle.svm.core.jdk.jfr.JfrOptions;
@@ -20,10 +46,10 @@ public class JfrAutoSessionManager {
     private static final String DEFAULT_JFR_FILENAME = "recording.jfr";
     private static final String DEFAULT_JFR_CONFIG = "default";
 
-    Configuration jfrConfiguration;
-    String filename;
-    Recording recording;
-    static JfrAutoSessionManager instance;
+    private final Configuration jfrConfiguration;
+    private String filename;
+    private Recording recording;
+    private static JfrAutoSessionManager instance;
 
     static void out(String msg) {
         JfrLogger.logInfo("JFR.AutoStart " + msg);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/JfrAutoSessionManager.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/JfrAutoSessionManager.java
@@ -1,0 +1,148 @@
+package com.oracle.svm.core.jdk.jfr.remote;
+
+import com.oracle.svm.core.jdk.jfr.JfrOptions;
+import com.oracle.svm.core.jdk.jfr.logging.JfrLogger;
+
+import jdk.jfr.Configuration;
+import jdk.jfr.Recording;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.text.ParseException;
+
+/*
+ * Handlers the startup and teardown of JFR when run from either the command line or remote interface.
+ * Implemented by standard JFR calls as user code might do.
+ */
+
+public class JfrAutoSessionManager {
+
+    private static final String DEFAULT_JFR_FILENAME = "recording.jfr";
+    private static final String DEFAULT_JFR_CONFIG = "default";
+
+    Configuration jfrConfiguration;
+    String filename;
+    Recording recording;
+    static JfrAutoSessionManager instance;
+
+    static void out(String msg) {
+        JfrLogger.logInfo("JFR.AutoStart " + msg);
+    }
+
+    JfrAutoSessionManager() throws IOException, ParseException {
+        this(DEFAULT_JFR_CONFIG);
+    }
+
+    JfrAutoSessionManager(String configName) throws IOException, ParseException {
+        out("JfrAutoSessionManager(" + configName + ")");
+        jfrConfiguration = Configuration.getConfiguration(configName);
+    }
+
+    /*
+     *   JFR-TODO if these timers expire after the main program has ended, the process hangs.
+     */
+    void startSession(String fn, long delayMilliseconds, long durationMilliseconds) {
+        if (delayMilliseconds > 0) {
+            out("scheduling JFR start in " + delayMilliseconds + "ms.");
+            new java.util.Timer().schedule(
+                    new java.util.TimerTask() {
+                        @Override
+                        public void run() {
+                            startSession(fn, 0, durationMilliseconds);
+                        }
+                    },
+                    delayMilliseconds
+            );
+        } else {
+            out("starting JFR session(" + fn + ")");
+            filename = fn;
+            recording = new Recording(jfrConfiguration);
+            recording.start();
+            try {
+                recording.setDestination(Paths.get(filename));
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            if (durationMilliseconds > 0) {
+                out("scheduling JFR stop in " + durationMilliseconds + "ms.");
+                new java.util.Timer().schedule(
+                        new java.util.TimerTask() {
+                            @Override
+                            public void run() {
+                                stopSession(true, false);
+                            }
+                        },
+                        durationMilliseconds
+                );
+            }
+        }
+    }
+
+    void stopSession(boolean write, boolean clear) {
+        out("stopSession(" + write + ", " + clear + ") start");
+        try {
+            if (recording != null) {
+                recording.close();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        out("stopSession(" + write + ", " + clear + ") stop");
+    }
+
+    public static void startupHook() {
+        out("Jfr startupHook() - start");
+        out(dumpJfrOptions(", "));
+        assert instance == null;
+        try {
+            // JFR-TODO fix JfrOptions to parse configuration name instead of using default "default"
+            instance = new JfrAutoSessionManager();
+            String fn = (JfrOptions.getRecordingFileName() != null && JfrOptions.getRecordingFileName().length() > 0) ? JfrOptions.getRecordingFileName() : DEFAULT_JFR_FILENAME;
+            instance.startSession(fn, JfrOptions.getRecordingDelay(), JfrOptions.getDuration());
+        } catch (IOException | ParseException e) {
+            e.printStackTrace();
+        }
+        out("Jfr startupHook() - end");
+    }
+
+    public static void shutdownHook() {
+        out("Jfr shutdownHook() - start instance is " + (instance == null ? "(null)" : instance.filename));
+        if (instance != null) {
+            instance.stopSession(true, true);
+        }
+        out("Jfr shutdownHook() - end");
+    }
+
+    @SuppressWarnings("unused")
+    private static String asString(Configuration cfg, String sep) {
+        return "name=\"" + cfg.getName() + "\"" + sep +
+                "label=\"" + cfg.getLabel() + "\"" + sep +
+                "description=\"" + cfg.getDescription() + "\"" + sep +
+                "settings=\"" + cfg.getSettings() + "\"";
+    }
+
+    public static String dumpJfrOptions(String sep) {
+        return "filename=\"" + JfrOptions.getRecordingFileName() + "\"" + sep +
+                "recordingName=\"" + JfrOptions.getRecordingName() + "\"" + sep +
+                "recordingSettingsFile=\"" + JfrOptions.getRecordingSettingsFile() + "\"" + sep +
+                "repositoryLocation=\"" + JfrOptions.getRepositoryLocation() + "\"" + sep +
+                "dumpOnExit=\"" + JfrOptions.getDumpOnExit() + "\"" + sep +
+                "persistToDisk=\"" + JfrOptions.isPersistedToDisk() + sep +
+                "pathToGcRoots=\"" + JfrOptions.trackPathToGcRoots() + "\"" + sep +
+                "sampleThreads=\"" + JfrOptions.isSampleThreadsEnabled() + "\"" + sep +
+                "retransform=\"" + JfrOptions.isRetransformEnabled() + "\"" + sep +
+                "sampleProtection=\"" + JfrOptions.isSampleProtectionEnabled() + "\"" + sep +
+                "delay=\"" + JfrOptions.getRecordingDelay() + "\"" + sep +
+                "duration=\"" + JfrOptions.getDuration() + "\"" + sep +
+                "maxAge=\"" + JfrOptions.getMaxAge() + "\"" + sep +
+                "maxChunkSize=\"" + JfrOptions.getMaxChunkSize() + "\"" + sep +
+                "globalBufferSize=\"" + JfrOptions.getGlobalBufferSize() + "\"" + sep +
+                "memorySize=\"" + JfrOptions.getMemorySize() + "\"" + sep +
+                "threadBufferSize=\"" + JfrOptions.getThreadBufferSize() + "\"" + sep +
+                "globalBufferCount=\"" + JfrOptions.getGlobalBufferCount() + "\"" + sep +
+                "oldObjectQueueSize=\"" + JfrOptions.getObjectQueueSize() + "\"" + sep +
+                "maxRecordingSize=\"" + JfrOptions.getMaxRecordingSize() + "\"" + sep +
+                "stackDepth=\"" + JfrOptions.getStackDepth() + "\"" + sep +
+                "logLevel=\"" + JfrOptions.getLogLevel() + "\"";
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/JfrAutoSessionManager.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/JfrAutoSessionManager.java
@@ -94,13 +94,17 @@ public class JfrAutoSessionManager {
         out("Jfr startupHook() - start");
         out(dumpJfrOptions(", "));
         assert instance == null;
-        try {
-            // JFR-TODO fix JfrOptions to parse configuration name instead of using default "default"
-            instance = new JfrAutoSessionManager();
-            String fn = (JfrOptions.getRecordingFileName() != null && JfrOptions.getRecordingFileName().length() > 0) ? JfrOptions.getRecordingFileName() : DEFAULT_JFR_FILENAME;
-            instance.startSession(fn, JfrOptions.getRecordingDelay(), JfrOptions.getDuration());
-        } catch (IOException | ParseException e) {
-            e.printStackTrace();
+        if (JfrOptions.getStartRecordingAutomatically()) {
+            try {
+                // JFR-TODO fix JfrOptions to parse configuration name instead of using default "default"
+                instance = new JfrAutoSessionManager();
+                String fn = (JfrOptions.getRecordingFileName() != null && JfrOptions.getRecordingFileName().length() > 0) ? JfrOptions.getRecordingFileName() : DEFAULT_JFR_FILENAME;
+                instance.startSession(fn, JfrOptions.getRecordingDelay(), JfrOptions.getDuration());
+            } catch (IOException | ParseException e) {
+                e.printStackTrace();
+            }
+        } else {
+            out("Jfr startupHook() - no auto start");
         }
         out("Jfr startupHook() - end");
     }


### PR DESCRIPTION
This PR adds the ability to start a Graal program and have Flight Recorder produce a JFR file with no JFR-specific code in the target source.

Delay and duration work but currently have some issues if there is still a timer running when the program exits.