### PR TITLE
add JFR remote service

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrFeature.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrFeature.java
@@ -32,12 +32,14 @@ import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.oracle.svm.core.jdk.RuntimeSupport;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
 
 import com.oracle.svm.core.annotate.AutomaticFeature;
 import com.oracle.svm.core.jdk.jfr.logging.JfrLogger;
+import com.oracle.svm.core.jdk.jfr.remote.JfrAutoSessionManager;
 import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.traceid.JfrTraceId;
 
 import jdk.internal.event.Event;
@@ -47,6 +49,15 @@ public class JfrFeature implements Feature {
     @Override
     public void afterRegistration(AfterRegistrationAccess access) {
         ImageSingletons.add(JfrRuntimeAccess.class, new JfrRuntimeAccessImpl());
+    }
+
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess access) {
+        if (JfrAvailability.withJfr) {
+            // JFR-TODO: test command line options for startup timer, file output, etc.
+            RuntimeSupport.getRuntimeSupport().addStartupHook(JfrAutoSessionManager::startupHook);
+            RuntimeSupport.getRuntimeSupport().addShutdownHook(JfrAutoSessionManager::shutdownHook);
+        }
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/JfrMetadataEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/JfrMetadataEvent.java
@@ -68,6 +68,18 @@ public class JfrMetadataEvent {
         assert (writer.isValid());
         assert (thread != null);
         assert (metadata != null);
+        if (metadata == null) {
+            System.err.println("XXXXXXXXXXXXXXXXXXXXXXXX    MDE.writeMetadata(): matadata is null; returning - JFR file will be corrupt");
+            try {
+                writer.writeUnbuffered(new byte[0], 0);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            return;
+        } else {
+            System.err.println("MDE.writeMetadata(): matadata is " + metadata.length + " bytes long");
+        }
+        if (writer == null) System.err.println("MDE: writer is null");
         try {
             writer.writeUnbuffered(metadata, metadata.length);
         } catch (IOException e) {
@@ -78,6 +90,20 @@ public class JfrMetadataEvent {
     // Called from JFR Java code
     public static void update(byte[] metadata) {
         JfrMetadataEvent.metadata = metadata;
+        /*
+        at com.oracle.svm.core.jdk.jfr.recorder.checkpoint.JfrMetadataEvent.update(JfrMetadataEvent.java:97)
+        at jdk.jfr.internal.JVM.storeMetadataDescriptor(JfrSubstitutions.java:731)
+        at jdk.jfr.internal.MetadataRepository.storeDescriptorInJVM(MetadataRepository.java:219)
+        at jdk.jfr.internal.MetadataRepository.setOutput(MetadataRepository.java:263)
+        at jdk.jfr.internal.PlatformRecorder.start(PlatformRecorder.java:230)
+        at jdk.jfr.internal.PlatformRecording.start(PlatformRecording.java:114)
+        at jdk.jfr.Recording.start(Recording.java:169)
+        at HelloWorld.main(HelloWorld.java:261)
+MDE.writeMetadata(): matadata is 76039 bytes long
+
+
+        System.err.println("MDE.update() called from");
+        new Exception("foo").printStackTrace(); */
         metadataId++;
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/InsecureValidatorImpl.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/InsecureValidatorImpl.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.remote;
+
+import com.sun.net.httpserver.HttpExchange;
+
+import java.io.IOException;
+
+public class InsecureValidatorImpl implements Validator {
+    @Override
+    public boolean validate(HttpExchange exchange) throws IOException {
+        return true;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/JfrAutoSessionManager.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/JfrAutoSessionManager.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.remote;
+
+import com.oracle.svm.core.SubstrateOptions;
+import com.oracle.svm.core.jdk.jfr.JfrOptions;
+import com.oracle.svm.core.jdk.jfr.logging.JfrLogger;
+
+import jdk.jfr.Configuration;
+import jdk.jfr.Recording;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.Date;
+
+/*
+ * Handlers the startup and teardown of JFR when run from either the command line or remote interface.
+ * Implemented by standard JFR calls as user code might do.
+ */
+
+public class JfrAutoSessionManager {
+
+    private static final String DEFAULT_JFR_CONFIG = "default";
+    private static final SimpleDateFormat fmt = new SimpleDateFormat("yyyy_MM_DD_HH_mm_ss");
+
+    private final Configuration jfrConfiguration;
+    private String filename;
+    private Recording recording;
+    private static JfrAutoSessionManager instance;
+
+    static void out(String msg) {
+        JfrLogger.logInfo("JFR.AutoStart " + msg);
+    }
+
+    JfrAutoSessionManager() throws IOException, ParseException {
+        this(DEFAULT_JFR_CONFIG);
+    }
+
+    JfrAutoSessionManager(String configName) throws IOException, ParseException {
+        out("JfrAutoSessionManager(" + configName + ")");
+        jfrConfiguration = Configuration.getConfiguration(configName);
+    }
+
+    /*
+     *   JFR-TODO: if these timers expire after the main program has ended, the process hangs.
+     */
+    void startSession(String fn, long delayMilliseconds, long durationMilliseconds) {
+        if (delayMilliseconds > 0) {
+            out("scheduling JFR start in " + delayMilliseconds + "ms.");
+            new java.util.Timer().schedule(
+                    new java.util.TimerTask() {
+                        @Override
+                        public void run() {
+                            startSession(fn, 0, durationMilliseconds);
+                        }
+                    },
+                    delayMilliseconds
+            );
+        } else {
+            out("starting JFR session(" + fn + ")");
+            filename = fn;
+            recording = new Recording(jfrConfiguration);
+            recording.start();
+            try {
+                recording.setDestination(Paths.get(filename));
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            if (durationMilliseconds > 0) {
+                out("scheduling JFR stop in " + durationMilliseconds + "ms.");
+                new java.util.Timer().schedule(
+                        new java.util.TimerTask() {
+                            @Override
+                            public void run() {
+                                stopSession(true, false);
+                            }
+                        },
+                        durationMilliseconds
+                );
+            }
+        }
+    }
+
+    void stopSession(boolean write, boolean clear) {
+        out("stopSession(" + write + ", " + clear + ") start");
+        try {
+            if (recording != null) {
+                recording.close();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        out("stopSession(" + write + ", " + clear + ") stop");
+    }
+
+    public void startSession() {
+        String fn = (JfrOptions.getRecordingFileName() != null && JfrOptions.getRecordingFileName().length() > 0) ? JfrOptions.getRecordingFileName() : getDefaultJfrFilename();
+        startSession(fn, JfrOptions.getRecordingDelay(), JfrOptions.getDuration());
+    }
+
+    public void stopSession() {
+        stopSession(true, true);
+    }
+
+    public static void startupHook() {
+        out("Jfr startupHook() - start");
+        out(dumpJfrOptions(", "));
+        assert instance == null;
+        if (JfrOptions.getStartRecordingAutomatically()) {
+            try {
+                // JFR-TODO fix JfrOptions to parse configuration name instead of using default "default"
+                instance = new JfrAutoSessionManager();
+                instance.startSession();
+            } catch (IOException | ParseException e) {
+                e.printStackTrace();
+            }
+        }
+        if (JfrOptions.getRemotePort() != -1) {
+            out("Jfr startupHook() - start remote control");
+            /* user specified remote control */
+            try {
+                // JFR-TODO fix JfrOptions to parse configuration name instead of using default "default"
+                if (instance == null) {
+                    instance = new JfrAutoSessionManager();
+                }
+                JfrRemoteWebService.buildAndStart(JfrOptions.getRemotePort(), JfrOptions.getRemoteProtocol());
+            } catch (IOException | ParseException e) {
+                e.printStackTrace();
+            }
+        }
+        out("Jfr startupHook() - end");
+    }
+
+    public static void shutdownHook() {
+        out("Jfr shutdownHook() - start instance is " + (instance == null ? "(null)" : instance.filename));
+        if (instance != null) {
+            instance.stopSession();
+        }
+        out("Jfr shutdownHook() - end");
+    }
+
+    @SuppressWarnings("unused")
+    private static String asString(Configuration cfg, String sep) {
+        return "name=\"" + cfg.getName() + "\"" + sep +
+                "label=\"" + cfg.getLabel() + "\"" + sep +
+                "description=\"" + cfg.getDescription() + "\"" + sep +
+                "settings=\"" + cfg.getSettings() + "\"";
+    }
+
+    public static String dumpJfrOptions(String sep) {
+        return "filename=\"" + JfrOptions.getRecordingFileName() + "\"" + sep +
+                "remote-port=\"" + JfrOptions.getRemotePort() + "\"" + sep +
+                "remote-protocol=\"" + JfrOptions.getRemoteProtocol() + "\"" + sep +
+                "recordingName=\"" + JfrOptions.getRecordingName() + "\"" + sep +
+                "recordingSettingsFile=\"" + JfrOptions.getRecordingSettingsFile() + "\"" + sep +
+                "repositoryLocation=\"" + JfrOptions.getRepositoryLocation() + "\"" + sep +
+                "dumpOnExit=\"" + JfrOptions.getDumpOnExit() + "\"" + sep +
+                "persistToDisk=\"" + JfrOptions.isPersistedToDisk() + sep +
+                "pathToGcRoots=\"" + JfrOptions.trackPathToGcRoots() + "\"" + sep +
+                "sampleThreads=\"" + JfrOptions.isSampleThreadsEnabled() + "\"" + sep +
+                "retransform=\"" + JfrOptions.isRetransformEnabled() + "\"" + sep +
+                "sampleProtection=\"" + JfrOptions.isSampleProtectionEnabled() + "\"" + sep +
+                "delay=\"" + JfrOptions.getRecordingDelay() + "\"" + sep +
+                "duration=\"" + JfrOptions.getDuration() + "\"" + sep +
+                "maxAge=\"" + JfrOptions.getMaxAge() + "\"" + sep +
+                "maxChunkSize=\"" + JfrOptions.getMaxChunkSize() + "\"" + sep +
+                "globalBufferSize=\"" + JfrOptions.getGlobalBufferSize() + "\"" + sep +
+                "memorySize=\"" + JfrOptions.getMemorySize() + "\"" + sep +
+                "threadBufferSize=\"" + JfrOptions.getThreadBufferSize() + "\"" + sep +
+                "globalBufferCount=\"" + JfrOptions.getGlobalBufferCount() + "\"" + sep +
+                "oldObjectQueueSize=\"" + JfrOptions.getObjectQueueSize() + "\"" + sep +
+                "maxRecordingSize=\"" + JfrOptions.getMaxRecordingSize() + "\"" + sep +
+                "stackDepth=\"" + JfrOptions.getStackDepth() + "\"" + sep +
+                "logLevel=\"" + JfrOptions.getLogLevel() + "\"";
+    }
+
+    /* NOTE: this changes every time it is called */
+    /* JFR-TODO - should this be the time of the start recording command? */
+    public static String getDefaultJfrFilename() {
+        String program = SubstrateOptions.Name.getValue().replaceAll("[:/\\\\]", "_");
+        if (program.isEmpty()) {
+            program = SubstrateOptions.Class.getValue().replaceAll("[$/]", "_");
+        }
+        long pid = ProcessHandle.current().pid();
+        int id = 1; /* JFR-TODO: don't know how to calculate id; maybe go to filesystem? */
+        return String.format("%s-pid-%d-id-%d-%s.jfr", program, pid, id, fmt.format(Date.from(Instant.now())));
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/JfrRemoteWebService.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/JfrRemoteWebService.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.remote;
+
+import com.oracle.svm.core.jdk.jfr.logging.JfrLogger;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/*
+  simple web service, no authentication yet.
+  requires --enable-all-security-services for https (currently added in NativeImageOptions)
+ */
+public class JfrRemoteWebService {
+
+    enum ServerMode {
+        STATUS_ONLY,
+        FULL_CONTROL
+    }
+
+    static final int HTTP_OK = 200;
+    @SuppressWarnings("unused") static final int HTTP_FORBIDDEN = 403;
+    static final int HTTP_BAD_REQUEST = 400;
+    @SuppressWarnings("unused") static final int HTTP_NOT_FOUND = 404;
+    @SuppressWarnings("unused") static final int HTTP_INTERNAL_ERROR = 500;
+    @SuppressWarnings("unused") static final int HTTP_NOT_IMPLEMENTED = 501;
+
+    private MiniServer server;
+    private boolean debug = true;
+    private boolean useHttps = true;
+    private int port = 0; // 0 for ephemeral port
+    private ServerMode mode = ServerMode.FULL_CONTROL;
+    private Validator validator = new InsecureValidatorImpl();
+    //private Validator validator = new SecureValidatorImpl("secret");
+
+    private JfrRemoteWebService() {
+        JfrLogger.logInfo("JFR.remote: JFR REMOTE ACTIVE");
+    }
+
+    private void addContexts(HttpServer server) {
+
+        if (getMode() == ServerMode.FULL_CONTROL) {
+            server.createContext("/start").setHandler(exchange -> {
+                JfrLogger.logInfo("JFR.remote: /start start");
+                if (!validateAndReturnError(exchange)) {
+                    return;
+                }
+                /* JFR-TODO: allow use to specify a filename */
+                final String response = "JfrRecorder: starting recording";
+                JfrLogger.logInfo("JFR.remote: /start 1");
+
+                JfrAutoSessionManager.instance.startSession();
+                JfrLogger.logInfo("JFR.remote: /start start 2");
+                respond(exchange, HTTP_OK, response);
+            });
+
+            server.createContext("/stop").setHandler(exchange -> {
+                if (!validateAndReturnError(exchange)) {
+                    return;
+                }
+
+                /*
+                r.stop();
+                r.dump(Files.createTempFile("my-recording", ".jfr"));
+                r.close();
+                 */
+                String response;
+                JfrAutoSessionManager.instance.stopSession();
+                response = "JfrRecorder: stopped recording";
+                response = response + "\n";
+                respond(exchange, HTTP_OK, response);
+            });
+
+            server.createContext("/exit").setHandler(exchange -> {
+                if (!validateAndReturnError(exchange)) {
+                    return;
+                }
+                final String response = "exiting remote control";
+                /* HTTP_NOT_IMPLEMENTED is for unimplemented HTTP methods; not unimplemented API calls. */
+                respond(exchange, HTTP_OK, response);
+                JfrRemoteWebService thiz = this;
+                // execute on another thread - otherwise deadlock since we're trying to stop this thread
+                new Thread() {
+                    @Override
+                    public void run() {
+                        thiz.stop();
+                    }
+                }.start();
+            });
+        }
+
+        server.createContext("/status").setHandler(exchange -> {
+
+            if (!validateAndReturnError(exchange)) {
+                return;
+            }
+
+            if (debug) {
+                JfrLogger.logInfo("JFR.remote: remote = " + exchange.getRemoteAddress() + " (" + exchange.getRemoteAddress().getHostName() + ")");
+                for (Map.Entry<String, List<String>> entry : exchange.getRequestHeaders().entrySet()) {
+                    JfrLogger.logInfo("JFR.remote:  hdr " + entry.getKey() + " = " + entry.getValue());
+                }
+            }
+
+            /* TODO
+            final String created = JfrRecorder.isCreated() ? "created" : "not created";
+            final String enabled = JfrRecorder.isEnabled() ? "enabled" : "not enabled";
+            final String recording = JfrRecorder.isRecording() ? "recording" : "not recording";
+            final String response = "JfrRecorder: status = " + created + ", " + enabled + ", " + recording + "\n";
+            */
+            final String response = "JFR Remote - status not available\n";
+            respond(exchange, HTTP_OK, response);
+        });
+    }
+
+    private void respond(HttpExchange exchange, int responseCode, String msg) throws IOException {
+        final String response = msg + '\n';
+        exchange.sendResponseHeaders(responseCode, response.getBytes().length);
+        OutputStream os = exchange.getResponseBody();
+        os.write(response.getBytes());
+        os.close();
+    }
+
+    private void error(HttpExchange exchange, int errorCode, String msg) throws IOException {
+        JfrLogger.logWarning("JFR.remote: rejected call from " + exchange.getRemoteAddress() + ": " + msg);
+        respond(exchange, errorCode, msg);
+    }
+
+    private boolean validateAndReturnError(HttpExchange exchange) throws IOException {
+        if (isDebug()) {
+            JfrLogger.logInfo("JFR.remote: remote = " + exchange.getRemoteAddress() + " (" + exchange.getRemoteAddress().getHostName() + ")");
+            for (Map.Entry<String, List<String>> entry : exchange.getRequestHeaders().entrySet()) {
+                JfrLogger.logInfo("JFR.remote:  hdr " + entry.getKey() + " = " + entry.getValue());
+            }
+        }
+
+        if (getValidator() != null && !getValidator().validate(exchange)) {
+            error(exchange, HTTP_BAD_REQUEST, "bad request");
+            return false;
+        }
+        return true;
+    }
+
+    @SuppressWarnings("unused")
+    private Map<String, String> splitQuery(final String query) {
+        if (query.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        final Map<String, String> map = new HashMap<>();
+        final String[] params = query.split("&");
+        for (final String param : params) {
+            final int idx = param.indexOf("=");
+            final String key = idx > 0 ? param.substring(0, idx) : param;
+            final String value = idx > 0 && param.length() > idx + 1 ? param.substring(idx + 1) : null;
+            map.put(key, value);
+        }
+        return Collections.unmodifiableMap(map);
+    }
+
+    private void dumpAddresses(MiniServer server) throws SocketException {
+        final Enumeration<NetworkInterface> e = NetworkInterface.getNetworkInterfaces();
+        while (e.hasMoreElements()) {
+            final NetworkInterface networkInterface = e.nextElement();
+            if (/*networkInterface.isPointToPoint() ||*/ networkInterface.isLoopback() || !networkInterface.isUp()) {
+                continue;
+            }
+            final Enumeration<InetAddress> ne = networkInterface.getInetAddresses();
+             while (ne.hasMoreElements()) {
+                final InetAddress addr = ne.nextElement();
+                if (addr.getClass() == Inet6Address.class) {
+                    continue;
+                }
+                final String protocol = server.isHttps() ? "https://" : "http://";
+                final String ifaceName = " (" + networkInterface.getDisplayName() + ")";
+                 JfrLogger.logInfo("JFR.remote: listening on " + protocol + addr.getHostName()  + ":" + server.getServer().getAddress().getPort() + " " + ifaceName);
+            }
+        }
+    }
+
+    public void start() throws IOException {
+        JfrLogger.logInfo("JFR.remote: JFR REMOTE start on port " + port);
+        server = new ServerFactory().createServer(port, useHttps);
+        addContexts(server.getServer());
+        /* note that the server thread is setDaemon(true) using JfrSubstitutions */
+        server.start();
+        dumpAddresses(server);
+    }
+
+    public void stop() {
+        MiniServer srv = this.server;
+        if (srv != null) {
+            JfrLogger.logInfo("JFR.remote: JFR REMOTE stopping on port " + port);
+            srv.stop();
+            server = null;
+        }
+    }
+
+    public static JfrRemoteWebService buildAndStart(int port, String protocol) throws IOException {
+        JfrLogger.logInfo("JFR.remote: JFR REMOTE buildAndStart");
+        JfrRemoteWebService remote = new JfrRemoteWebService();
+        remote.setPort(port);
+        remote.setUseHttps("https".equals(protocol));
+        remote.start();
+        return remote;
+    }
+
+    @SuppressWarnings("unused")
+    private void setDebug(boolean d) {
+        debug = d;
+    }
+
+    private boolean isDebug() {
+        return debug;
+    }
+
+    private ServerMode getMode() {
+        return mode;
+    }
+
+    @SuppressWarnings("unused")
+    private void setMode(ServerMode mode) {
+        this.mode = mode;
+    }
+
+    private void setUseHttps(boolean useHttps) {
+        this.useHttps = useHttps;
+    }
+
+    @SuppressWarnings("unused")
+    private int getPort() {
+        return this.port;
+    }
+
+    private void setPort(int port) {
+        this.port = port;
+    }
+
+    private Validator getValidator() {
+        return validator;
+    }
+
+    @SuppressWarnings("unused")
+    private void setValidator(Validator validator) {
+        this.validator = validator;
+    }
+}
+

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/MiniHttpServerImpl.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/MiniHttpServerImpl.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.remote;
+
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+class MiniHttpServerImpl implements MiniServer {
+
+    private HttpServer server;
+    private ExecutorService threadPool = null;
+
+    MiniHttpServerImpl(int port) throws IOException {
+        createServer(port);
+        //addContexts(server);
+    }
+
+    private void createServer(int listenPort) throws IOException {
+        server = HttpServer.create(new InetSocketAddress(listenPort), 0);
+        ThreadFactory tf = new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread t = new Thread();
+                t.setDaemon(true);
+                return t;
+            }
+        };
+        threadPool = Executors.newFixedThreadPool(5, tf);
+        this.server.setExecutor(threadPool);
+    }
+
+    @Override
+    public void start() {
+        server.start();
+    }
+
+    @Override
+    public void stop() {
+        server.stop(1);
+        threadPool.shutdownNow();
+        try {
+            threadPool.awaitTermination(2, TimeUnit.MINUTES);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public HttpServer getServer() {
+        return server;
+    }
+
+    @Override
+    public boolean isHttps() { return false; }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/MiniHttpsServerImpl.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/MiniHttpsServerImpl.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.remote;
+
+import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsParameters;
+import com.sun.net.httpserver.HttpsServer;
+import sun.security.tools.keytool.CertAndKeyGen;
+import sun.security.x509.X500Name;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+class MiniHttpsServerImpl implements MiniServer {
+
+    private HttpsServer server = null;
+    private ExecutorService threadPool = null;
+
+    MiniHttpsServerImpl(int port) throws IOException {
+        createServer(port);
+        //addContexts(server);
+    }
+
+    /***
+    // to create the keystore:
+    // keytool -genkey -alias alias -keypass jstjst -keystore jst.keystore -storepass jstjst
+    private KeyStore loadKeystore(String filename, String password) throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
+        // initialise the keystore from a file
+        char[] pwd = password.toCharArray();
+        KeyStore ks = KeyStore.getInstance("JKS");
+        FileInputStream fis = new FileInputStream(filename);
+        ks.load(fis, pwd);
+        return ks;
+    }
+     ****/
+
+    private KeyStore createSelfSignedKeyStore() {
+        try {
+            CertAndKeyGen keyGen = new CertAndKeyGen("RSA","SHA1WithRSA",null);
+            keyGen.generate(1024);
+            PrivateKey topPrivateKey = keyGen.getPrivateKey();
+            // Generate the self signed certificate
+            X509Certificate cert = keyGen.getSelfCertificate(new X500Name("CN=ROOT"), (long)365*24*3600);
+
+            KeyStore keyStore = KeyStore.getInstance("jks");
+            keyStore.load(null,null);
+            X509Certificate[] chain = new X509Certificate[1];
+            chain[0] = cert;
+            keyStore.setKeyEntry("jst", topPrivateKey, "jstjst".toCharArray(), chain);
+            return keyStore;
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+        return null;
+    }
+
+    private void createServer(int listenPort) throws IOException{
+
+        try {
+            server = HttpsServer.create(new InetSocketAddress(listenPort), 0);
+            ThreadFactory tf = new ThreadFactory() {
+                @Override
+                public Thread newThread(Runnable r) {
+                    Thread t = new Thread();
+                    t.setDaemon(true);
+                    return t;
+                }
+            };
+            threadPool = Executors.newFixedThreadPool(5, tf);
+            this.server.setExecutor(threadPool);
+
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+
+            String password = "jstjst";
+            //KeyStore ks = loadKeystore("jst.keystore", password);
+            KeyStore ks = createSelfSignedKeyStore();
+
+            // setup the key manager factory
+            KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+            kmf.init(ks, password.toCharArray());
+
+            // setup the trust manager factory
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
+            tmf.init(ks);
+
+            // setup the HTTPS context and parameters
+            sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+            server.setHttpsConfigurator(new HttpsConfigurator(sslContext) {
+                public void configure(HttpsParameters params) {
+                    try {
+                        // initialise the SSL context
+                        SSLContext c = SSLContext.getDefault();
+                        SSLEngine engine = c.createSSLEngine();
+                        params.setNeedClientAuth(false);
+                        params.setCipherSuites(engine.getEnabledCipherSuites());
+                        params.setProtocols(engine.getEnabledProtocols());
+
+                        // get the default parameters
+                        SSLParameters defaultSSLParameters = c.getDefaultSSLParameters();
+                        params.setSSLParameters(defaultSSLParameters);
+                    } catch (Exception ex) {
+                        ex.printStackTrace();
+                    }
+                }
+            });
+        } catch ( Exception exception )  {
+            exception.printStackTrace();
+            throw new IOException(exception.getMessage());
+        }
+
+        server.setExecutor(null); // creates a default executor
+    }
+
+    /**
+    void addContexts(HttpServer server) {
+        server.createContext("/", httpExchange -> {
+            String response = "This is the response";
+            System.err.println("request from " + httpExchange.getRemoteAddress().getHostName());
+            httpExchange.sendResponseHeaders(200, response.getBytes().length);
+            OutputStream os = httpExchange.getResponseBody();
+            os.write(response.getBytes());
+            os.close();
+        });
+    }****/
+
+    public void start() { server.start(); }
+
+    public void stop() {
+        server.stop(1);
+        threadPool.shutdownNow();
+        try {
+            threadPool.awaitTermination(2, TimeUnit.MINUTES);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public HttpServer getServer() {
+        return server;
+    }
+
+    @Override
+    public boolean isHttps() { return true; }
+
+    public static void main(String[] args) throws IOException {
+        new MiniHttpsServerImpl(8443).start();
+    }
+}
+
+
+

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/MiniServer.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/MiniServer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.remote;
+
+import com.sun.net.httpserver.HttpServer;
+
+public interface MiniServer {
+
+    void start();
+    void stop();
+    boolean isHttps();
+    HttpServer getServer();
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/SecureValidatorImpl.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/SecureValidatorImpl.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.remote;
+
+import com.sun.net.httpserver.HttpExchange;
+
+import java.io.IOException;
+
+public class SecureValidatorImpl implements Validator {
+
+    static String secret = null;
+
+    SecureValidatorImpl(String secret) {
+        this.secret = secret;
+    }
+
+    /* return false if not allowed */
+    public boolean validate(HttpExchange exchange) throws IOException {
+
+        final String apiKey = exchange.getRequestHeaders().getFirst("X-api-key");
+
+        if (apiKey == null) {
+            return false;
+        }
+
+        final String hostname = exchange.getRemoteAddress().getHostName();
+        return validateHostAndApiKey(hostname, apiKey);
+    }
+
+
+    /* return false if not allowed */
+    private boolean validateHostAndApiKey(String hostName, String apiKey) throws IOException {
+
+        if (secret != null && !apiKey.equals(secret)) {
+            /* secret does not match */
+            return false;
+        }
+
+        /* JFR-TODO: validate host (is locahost or on list) */
+        return true;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/ServerFactory.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/ServerFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.remote;
+
+import java.io.IOException;
+
+public class ServerFactory {
+
+    MiniServer createServer(int port, boolean useHttps) throws IOException {
+        return useHttps ? new MiniHttpsServerImpl(port) : new MiniHttpServerImpl(port);
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/Validator.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/Validator.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.remote;
+
+import com.sun.net.httpserver.HttpExchange;
+
+import java.io.IOException;
+
+public interface Validator {
+
+    boolean validate(HttpExchange exchange) throws IOException;
+}

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageOptions.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageOptions.java
@@ -29,6 +29,7 @@ import static org.graalvm.compiler.options.OptionType.User;
 
 import java.util.Arrays;
 
+import com.oracle.svm.core.SubstrateOptions;
 import org.graalvm.collections.EconomicMap;
 import org.graalvm.compiler.options.Option;
 import org.graalvm.compiler.options.OptionKey;
@@ -117,6 +118,9 @@ public class NativeImageOptions {
             if (newValue) {
                 AllowIncompleteClasspath.update(values, true);
                 JfrAvailability.withJfr = true;
+                /* these security services are only required for JFR remote, and only if HTTPS is required */
+                // JFR-TODO: add build-time option to add remote control code to executable instead of always
+                SubstrateOptions.EnableAllSecurityServices.update(values, true);
             }
         }
     };


### PR DESCRIPTION
This PR adds a simple HTTPS web service to start and stop JFR reocrding.
Current issues:
- cannot disable at build time (the server code is always repent if JFR is compiled in)
- cannot specify a secret for security
- does not look like JMX

This PR is build on top of the options PR and the command line startup PR.