### PR TITLE
Add compile-time static JFR configurations

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrFeature.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrFeature.java
@@ -33,8 +33,10 @@ import java.util.HashSet;
 import java.util.Set;
 
 import com.oracle.svm.core.jdk.RuntimeSupport;
+import com.oracle.svm.core.jdk.jfr.remote.JfrStaticConfigurations;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
 
 import com.oracle.svm.core.annotate.AutomaticFeature;
@@ -55,6 +57,7 @@ public class JfrFeature implements Feature {
     public void beforeAnalysis(BeforeAnalysisAccess access) {
         if (JfrAvailability.withJfr) {
             // JFR-TODO: test command line options for startup timer, file output, etc.
+            RuntimeClassInitialization.initializeAtBuildTime(JfrStaticConfigurations.class);
             RuntimeSupport.getRuntimeSupport().addStartupHook(JfrAutoSessionManager::startupHook);
             RuntimeSupport.getRuntimeSupport().addShutdownHook(JfrAutoSessionManager::shutdownHook);
         }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrOptions.java
@@ -79,6 +79,7 @@ public class JfrOptions {
     private static final String REPOSITORY = "repository";
     // Arguments from JfrDcmds.cpp
     private static final String DUMPONEXIT = "dumponexit";
+    private static final String FILENAME = "filename";
     private static final String NAME = "name";
     private static final String SETTINGS = "settings";
     private static final String DELAY = "delay";
@@ -179,7 +180,6 @@ public class JfrOptions {
         return true;
     }
 
-
     public static boolean parseStartFlightRecordingOption(String args) {
         if (args.equals("")) {
             // -XX:StartFlightRecording without any delimiter and values
@@ -236,6 +236,9 @@ public class JfrOptions {
                         break;
                     case DISK:
                         persistToDisk = Boolean.parseBoolean(val);
+                        break;
+                    case FILENAME:
+                        filename = val;
                         break;
                     case GCROOTS:
                         pathToGcRoots = Boolean.parseBoolean(val);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/JfrStaticConfigurations.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/JfrStaticConfigurations.java
@@ -1,0 +1,46 @@
+package com.oracle.svm.core.jdk.jfr.remote;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.jdk.jfr.JfrAvailability;
+import jdk.jfr.Configuration;
+import jdk.jfr.internal.JVMSupport;
+import jdk.jfr.internal.jfc.JFC;
+
+import java.io.IOException;
+import java.text.ParseException;
+
+import static jdk.jfr.Configuration.getConfiguration;
+
+public final class JfrStaticConfigurations {
+
+    public static Configuration DEFAULT;
+    public static Configuration PROFILE;
+
+    /* initialized at build time */
+    /* See JfrFeature: RuntimeClassInitialization.initializeAtBuildTime(JfrStaticConfigurations.class); */
+    static {
+        try {
+            DEFAULT = getConfiguration("default");
+            PROFILE = getConfiguration("profile");
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+    }
+}
+
+@TargetClass(className = "jdk.jfr.Configuration", onlyWith = JfrAvailability.WithJfr.class)
+final class Target_jdk_jfr_Configuration {
+    @Substitute
+    static Configuration getConfiguration(String name) throws IOException, ParseException {
+        if ("default".equals(name)) {
+            return JfrStaticConfigurations.DEFAULT;
+        } else if ("profile".equals(name)) {
+            return JfrStaticConfigurations.PROFILE;
+        } else {
+            throw new IOException("unknown JFR configuration " + name);
+        }
+    }
+}


### PR DESCRIPTION
This PR embeds the standard JFR profile and default configs into a graal executable, and patches the Configuration class to use them.